### PR TITLE
checks for correctly created FIFO and starts filling FIFO before rngd access it

### DIFF
--- a/entropyservice-client.sh
+++ b/entropyservice-client.sh
@@ -3,10 +3,24 @@ USER="entropyservice"
 SERVER="yourserver.tld"
 FIFO="/etc/rdcentropyservice"
 
-echo -ne "Starting rngd to stir external entropy into local entropy pool..."
-rngd -r $FIFO --fill-watermark=90% --feed-interval=1 --rng-timeout=0 --random-step=256 &
-echo "done."
+# check for and correct $FIFO as a FIFO pipe
+
+if ! [ -p "$FIFO" ]; then
+        echo "$FIFO is not a FIFO or is missing"
+        if [ -e "$FIFO" ] ; then
+                rm "$FIFO"
+        fi
+        mknod "$FIFO" p && echo "mknod $FIFO created as a FIFO"
+else
+        echo "$FIFO exists and is a FIFO"
+fi
+
+# start filling $FIFO so it's not depleted when we stir entropy into /dev/random using rngd
 
 echo -ne "Connecting to remote entropy pool..."
-ssh $USER@$SERVER "cat /dev/random" > $FIFO &
-echo "done."
+ssh  $USER@$SERVER "cat /dev/random" > $FIFO &
+echo  "done."
+
+echo -ne "Starting rngd to stir external entropy into local entropy pool..."
+rngd -r $FIFO --fill-watermark=90% --feed-interval=1 --rng-timeout=0 --random-step=256 &
+echo  "done."

--- a/entropyservice-client.sh
+++ b/entropyservice-client.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+# original https://github.com/arussell/entropyservice
+
 USER="entropyservice"
 SERVER="yourserver.tld"
 FIFO="/etc/rdcentropyservice"

--- a/entropyservice-install.sh
+++ b/entropyservice-install.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+# original https://github.com/arussell/entropyservice
+
 if [ -f /etc/debian_version ]; then
   aptitude install rng-tools -y
 fi

--- a/entropyservice-install.sh
+++ b/entropyservice-install.sh
@@ -5,4 +5,3 @@ fi
 if [ -f /etc/redhat-release ]; then
   yum install rng-utils
 fi
-mknod /etc/rdcentropyservice p


### PR DESCRIPTION
Added a check that /etc/rdcentropyservice exists and is a FIFO else corrects it. 
This in fact makes the mknod in the entropyservice-install.sh redundant : removed it

Reversed the order of the two main commands thus start the ssh and feed the FIFO before we stir entropy using rngd in case FIFO is depleted which otherwise caused the whole thing to stop.
